### PR TITLE
npm audit fix --force

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,11 +14,11 @@
   "author": "Franco Bouly (@rayfranco)",
   "license": "MIT",
   "dependencies": {
-    "debug": "~2.2.0",
+    "debug": "^4.0.1",
     "defaults": "~1.0.3",
-    "superagent": "~1.6.1"
+    "superagent": "^3.8.3"
   },
   "devDependencies": {
-    "mocha": "^2.3.4"
+    "mocha": "^5.2.0"
   }
 }


### PR DESCRIPTION
Bump `debug`, `superagent` and `mocha` packages to avoid noises caused by `npm audit`.