### PR TITLE
Support calls/:id/insight_cards endpoint

### DIFF
--- a/lib/calls.js
+++ b/lib/calls.js
@@ -29,3 +29,11 @@ Calls.prototype.link = function(id, link, callback, options) {
 
   this.API.post('/calls/' + id +'/link', options, callback);
 };
+
+Calls.prototype.insightCards = function(id, contents, callback, options) {
+  options = defaults(options, {
+    contents
+  });
+
+  this.API.post('/calls/' + id + '/insight_cards', options, callback);
+}

--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
-  "name": "aircall",
-  "version": "0.1.0",
+  "name": "@govirtuo/aircall",
+  "version": "0.2.0",
   "description": "Aircall API for node",
   "main": "./lib",
-  "repository": "git://github.com/rayfranco/aircall.git",
+  "repository": "git://github.com/govirtuo/aircall.git",
   "keywords": [
     "aircall",
     "API"


### PR DESCRIPTION
This PR allows to use the insight-cards endpoint from the client.